### PR TITLE
[BUG] Destroy method creating wrong key for environment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contentful_redis (0.0.4)
+    contentful_redis (0.0.5)
       faraday
       redis-store
 

--- a/lib/contentful_redis.rb
+++ b/lib/contentful_redis.rb
@@ -6,7 +6,7 @@ require_relative 'contentful_redis/model_base'
 # Dir["#{Dir.pwd}/lib/contentful_redis/**/*.rb"].each { |f| require f }
 
 module ContentfulRedis
-  VERSION = '0.0.4'.freeze
+  VERSION = '0.0.5'.freeze
 
   class << self
     attr_writer :configuration

--- a/lib/contentful_redis/model_base.rb
+++ b/lib/contentful_redis/model_base.rb
@@ -87,7 +87,7 @@ module ContentfulRedis
     end
 
     def destroy
-      keys = [ContentfulRedis::KeyManager.content_model_key(self.class.space, self.class.send(:request_env, nil),
+      keys = [ContentfulRedis::KeyManager.content_model_key(self.class.space, endpoint,
                                                             'sys.id': id, content_type: self.class.content_model,
                                                             include: 1)]
 
@@ -103,6 +103,12 @@ module ContentfulRedis
     end
 
     private
+
+    def endpoint
+      env = self.class.send(:request_env, nil)
+
+      env.to_s.downcase == 'published' ? 'cdn' : 'preview'
+    end
 
     def entries_as_objects(model)
       entries = model.dig('includes', 'Entry')

--- a/spec/contentful_redis/model_base_spec.rb
+++ b/spec/contentful_redis/model_base_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe ContentfulRedis::ModelBase, contentful: true do
     end
 
     describe '#destroy(id)' do
-      let(:content_model_key) { "xxxx/published/sys.id-#{subject.id}/content_type-#{subject.class.content_model}/include-1" }
+      let(:content_model_key) { "xxxx/cdn/sys.id-#{subject.id}/content_type-#{subject.class.content_model}/include-1" }
       # Simulating id to be a searchable field
       let(:attribute_index_key) { "xxxx/#{subject.class.content_model}/#{subject.id}" }
 
@@ -203,7 +203,7 @@ RSpec.describe ContentfulRedis::ModelBase, contentful: true do
     end
 
     describe '#destroy' do
-      let(:content_model_key) { "xxxx/published/sys.id-#{subject.id}/content_type-#{subject.class.content_model}/include-1" }
+      let(:content_model_key) { "xxxx/cdn/sys.id-#{subject.id}/content_type-#{subject.class.content_model}/include-1" }
       # Simulating id to be a searchable field
       let(:attribute_index_key) { "xxxx/#{subject.class.content_model}/#{subject.id}" }
 
@@ -231,6 +231,22 @@ RSpec.describe ContentfulRedis::ModelBase, contentful: true do
         subject.destroy
 
         expect(ContentfulRedis.redis.exists(attribute_index_key)).to be false
+      end
+    end
+  end
+
+  describe '#endpoint' do
+    context 'when environment for is published' do
+      it 'return endpoint for the environment' do
+        expect(subject.send(:endpoint)).to eq 'cdn'
+      end
+    end
+
+    context 'when environment for is preview' do
+      it 'return endpoint for the environment' do
+        allow(subject.class).to receive(:request_env).and_return(:preview)
+
+        expect(subject.send(:endpoint)).to eq 'preview'
       end
     end
   end


### PR DESCRIPTION
Destroy menthod was using environment name as the part of the key
Updated this with endpoint which is different for published and preview
Updated specs
Bumped minor version