### PR TITLE
OPTION TO RETUEN NIL FOR find_by

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contentful_redis (0.1.0)
+    contentful_redis (0.1.1)
       faraday
       redis-store
 
@@ -42,7 +42,7 @@ GEM
     public_suffix (3.0.3)
     rainbow (3.0.0)
     rake (12.3.1)
-    redis (4.0.3)
+    redis (4.0.2)
     redis-store (1.6.0)
       redis (>= 2.2, < 5)
     rspec (3.8.0)

--- a/lib/contentful_redis.rb
+++ b/lib/contentful_redis.rb
@@ -6,7 +6,7 @@ require_relative 'contentful_redis/model_base'
 # Dir["#{Dir.pwd}/lib/contentful_redis/**/*.rb"].each { |f| require f }
 
 module ContentfulRedis
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 
   class << self
     attr_writer :configuration

--- a/lib/contentful_redis/model_base.rb
+++ b/lib/contentful_redis/model_base.rb
@@ -20,7 +20,7 @@ module ContentfulRedis
       end
 
       def find_by(args = {})
-        unless (args.keys - [searchable_fields, :options].flatten).empty?
+        unless (args.keys - [searchable_fields, :options, :return_nil].flatten).empty?
           raise ContentfulRedis::Error::ArgumentError, "#{args} contain fields which are not a declared as a searchable field"
         end
 
@@ -29,7 +29,11 @@ module ContentfulRedis
           key.nil? || key.empty? ? nil : ContentfulRedis.redis.get(key)
         end.compact.first
 
-        raise ContentfulRedis::Error::RecordNotFound, 'Missing attribute in glossary' if id.nil?
+        if id.nil?
+          return nil if args[:return_nil]
+
+          raise ContentfulRedis::Error::RecordNotFound, 'Missing attribute in glossary'
+        end
 
         find(id, args.fetch(:options, {}))
       end


### PR DESCRIPTION
Why  : Model find_by raises error on missing key
What : Added an option to return nil without raising error