### PR TITLE
uninitialized constant Faraday

### DIFF
--- a/lib/contentful_redis/request.rb
+++ b/lib/contentful_redis/request.rb
@@ -2,6 +2,7 @@
 
 require_relative 'key_manager'
 require_relative 'error'
+require 'faraday'
 
 # Request from contentful api and store in redis.
 # Atempt to fetch response from redis before requesting to the contentful api


### PR DESCRIPTION
Faraday was not required anywhere.

This caused an `uninitialized constant Faraday` on the national-library